### PR TITLE
Fixed n_components issue with magic_sauce

### DIFF
--- a/dlatk/dlaConstants.py
+++ b/dlatk/dlaConstants.py
@@ -150,17 +150,17 @@ DEF_COMB_MODELS = ['ridgecv']
 DEF_FOLDS = 5
 DEF_OUTLIER_THRESHOLD = 2.5
 DEF_RP_FEATURE_SELECTION_MAPPING = {
-    'magic_sauce': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", PCA(n_components=max(int(X.shape[0]/(len(self.featureGetters)+0.1)), min(min(50,X.shape[0]), X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
+    'magic_sauce': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", WrappedPCA(n_components=max(int(X.shape[0]/(len(self.featureGetters)+0.1)), min(min(50,X.shape[0]), X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
 
-    'magic_sauce_light': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=100.0)), ("3_rpca", PCA(n_components=max(int(X.shape[0]/(len(self.featureGetters)+0.3)), min(50, X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
+    'magic_sauce_light': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=100.0)), ("3_rpca", WrappedPCA(n_components=max(int(X.shape[0]/(len(self.featureGetters)+0.3)), min(50, X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
 
-    'magic200': 'Pipeline([("1_univariate_select", SelectFwe(alpha=60.0, score_func=f_regression)), ("2_rpca", PCA(copy=True, iterated_power=3, n_components=200, random_state=42, whiten=False, svd_solver="randomized"))])',
+    'magic200': 'Pipeline([("1_univariate_select", SelectFwe(alpha=60.0, score_func=f_regression)), ("2_rpca", WrappedPCA(copy=True, iterated_power=3, n_components=200, random_state=42, whiten=False, svd_solver="randomized"))])',
 
-    'k_magic_sauce': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", PCA(n_components=int(self.n_components), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
+    'k_magic_sauce': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", WrappedPCA(n_components=int(self.n_components), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
     
     'topic_ngram_ms': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", PCA(n_components=max(int(2*(X.shape[0]*.20)/len(self.featureGetters) if X.shape[1] > 2000 else 2*(X.shape[0]*.75)/len(self.featureGetters)), min(50, X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
 
-    'magic_sauce_1pct': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", PCA(n_components=min(int((X.shape[0]/(len(self.featureGetters)+0.1))*.001), int(X.shape[1]*0.2)), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
+    'magic_sauce_1pct': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", WrappedPCA(n_components=min(int((X.shape[0]/(len(self.featureGetters)+0.1))*.001), int(X.shape[1]*0.2)), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
 
     'topic_ngram_ms': 'Pipeline([("1_mean_value_filter", OccurrenceThreshold(threshold=int(sqrt(X.shape[0]*10000)))), ("2_univariate_select", SelectFwe(f_regression, alpha=60.0)), ("3_rpca", PCA(n_components=max(int(2*(X.shape[0]*.20)/len(self.featureGetters) if X.shape[1] > 2000 else 2*(X.shape[0]*.75)/len(self.featureGetters)), min(50, X.shape[1])), random_state=42, whiten=False, iterated_power=3, svd_solver="randomized"))])',
 

--- a/dlatk/regressionPredictor.py
+++ b/dlatk/regressionPredictor.py
@@ -60,7 +60,7 @@ from .classifyPredictor import ClassifyPredictor
 from .dimensionReducer import PPA
 from .mysqlmethods import mysqlMethods as mm
 from .dlaConstants import DEFAULT_MAX_PREDICT_AT_A_TIME, DEFAULT_RANDOM_SEED, warn, MinScaler
-
+from .wrappedPCA import WrappedPCA
 
 def alignDictsAsXy(X, y, sparse = False, returnKeyList = False, keys = None):
     """turns a list of dicts for x and a dict for y into a matrix X and vector y"""

--- a/dlatk/wrappedPCA.py
+++ b/dlatk/wrappedPCA.py
@@ -1,0 +1,17 @@
+from sklearn.decomposition import PCA 
+
+class WrappedPCA(PCA):
+    """Wrapper around sklearn.decomposition.PCA to maintain the right n_components
+    when magic_sauce (and other methods from the same family) is used for feature selection.
+
+    All methods and attributes are inherited from sklearn.decomposition.PCA, 
+    except _fit() which is overridden here. For details refer 
+    https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/decomposition/_pca.py
+    """
+
+    def _fit(self, X): 
+    
+        n_samples, n_features = X.shape
+        self.n_components = min(self.n_components, min(n_samples, n_features))
+
+        return super()._fit(X)


### PR DESCRIPTION
`n_components` was more than `min(n_samples, n_features)` in PCA when magic_sauce feature selection was used. This was fixed with a wrapper (`WrappedPCA`) around the `sklearn.decomposition.PCA` class that checks for the right `n_components`.