### PR TITLE
fixed an issue with --add_corp_lex_table

### DIFF
--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1843,15 +1843,16 @@ class FeatureExtractor(DLAWorker):
 
         rowsToInsert = []
 
-        isql = "INSERT IGNORE INTO "+tableName+" (term, category, weight) values (%s, %s, %s)"
+        isql = "INSERT IGNORE INTO "+tableName+" (id, term, category, weight) values (%s, %s, %s, %s)"
         reporting_percent = 0.01
         reporting_int = max(floor(reporting_percent * len(feat_cat_weight)), 1)
         featIdCounter = 0
 
+        i = 0
         for feat in feat_cat_weight:
-            sql = """SELECT feat, avg(group_norm) FROM %s WHERE feat LIKE "%s" """ % (wordTable, mm.MySQLdb.escape_string(feat))
-            attributeRows = mm.executeGetList(self.corpdb, self.dbCursor, sql, False, charset=self.encoding, use_unicode=self.use_unicode, mysql_config_file=self.mysql_config_file)[0]
-            if attributeRows[0]:
+            sql = """SELECT feat, avg(group_norm) FROM {} WHERE feat LIKE "%s" GROUP BY feat""".format(wordTable)
+            attributeRows = mm.executeGetList(self.corpdb, self.dbCursor, sql, True, charset=self.encoding, use_unicode=self.use_unicode, mysql_config_file=self.mysql_config_file, query_params=[feat])
+            if len(attributeRows) > 0:
                 rows = [(feat, topic, str(feat_cat_weight[feat][topic]*attributeRows[1])) for topic in feat_cat_weight[feat]]
 
             rowsToInsert.extend(rows)

--- a/dlatk/mysqlmethods/mysqlMethods.py
+++ b/dlatk/mysqlmethods/mysqlMethods.py
@@ -23,6 +23,7 @@ def dbConnect(db, charset=DEF_ENCODING, use_unicode=DEF_UNICODE_SWITCH, mysql_co
                 db = db,
                 charset = charset,
                 use_unicode = use_unicode, 
+                local_infile=True,
                 read_default_file = mysql_config_file
             )
             break
@@ -138,7 +139,7 @@ def executeGetDict( db, dictCursor, sql, warnQuery=False, charset=DEF_ENCODING, 
                 sys.exit(1)
     return data
 
-def executeGetList( db, dbCursor, sql, warnQuery=True, charset=DEF_ENCODING, use_unicode=DEF_UNICODE_SWITCH, mysql_config_file=MYSQL_CONFIG_FILE):
+def executeGetList( db, dbCursor, sql, warnQuery=True, charset=DEF_ENCODING, use_unicode=DEF_UNICODE_SWITCH, mysql_config_file=MYSQL_CONFIG_FILE, query_params=None):
     """Executes a given query, returns results as a list of lists"""
     warnQuery = False
     if warnQuery:
@@ -147,7 +148,10 @@ def executeGetList( db, dbCursor, sql, warnQuery=True, charset=DEF_ENCODING, use
     attempts = 0;
     while (1):
         try:
-            dbCursor.execute(sql)
+            if query_params is None:
+                dbCursor.execute(sql)
+            else:
+                dbCursor.execute(sql, query_params)
             data = dbCursor.fetchall()
             break
         except MySQLdb.Error as e:


### PR DESCRIPTION
More recent versions of MySQL disallow a grouped selection without specifying a `GROUP BY` clause. This fixes an error in `--add_corp_lex_table` caused by this change.

I have been using DLATK successfully with this change, so I think it's fine. But I don't ever use DLATK's MySQL methods outside of DLATK itself, so it would be great if someone who does (@sjgiorgi, I think) could double check the changes to `executeGetList()` won't cause problems before merging.