### PR TITLE
POS bug fixes

### DIFF
--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -2439,7 +2439,7 @@ class FeatureExtractor(DLAWorker):
 
 
                     pos_list = []
-                    if posMessageTable[-4:] != 'tpos':
+                    if posMessageTable[-4:] == 'tpos':
                         if keep_words:
                             dlac.warn("keep words not implemented yet for tweetpos tags")
                         else:##TODO: Debug; make sure this works

--- a/dlatk/lib/StanfordParser.py
+++ b/dlatk/lib/StanfordParser.py
@@ -116,7 +116,7 @@ class StanfordParser:
 
 
 def shortenToNWords(sent, n):
-    words = removeNonAscii(sent)
+    words = removeNonAscii(sent).split(' ')
     return ' '.join(words[:int(n)])
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've fixed below issues in different parts of the POS pipeline - 

- In `dlatk/featureExtractor.py`, where we pick between TweetPOS tagger and Stanford passer, the if condition has to be the other way round based on the warning below.
- In `dlatk/lib/StanfordParser.py` where pick the top N words from a sentence, added a `split(' ')` to get the words. Else it tags every character.

I've tested the fix to successfully extract the POS tags for the tweets.