### PR TITLE
Fix the regular expression lexInterface.py

### DIFF
--- a/dlatk/lexicainterface/lexInterface.py
+++ b/dlatk/lexicainterface/lexInterface.py
@@ -154,7 +154,7 @@ def loadWeightedLexiconFromSparse(filename):
     """Loads the perma lexicon from a sparse formatting word[, word], category
     returns a dictionary of frozensets"""
     lexFile = open(filename)
-    comma = re.compile(r'\,\s*')
+    comma = re.compile(r'\,|\s')
     cats = [] 
     lexicon = {}
     for line in lexFile:


### PR DESCRIPTION
EDIT: Closing this - I didn't realize that I didn't have a CSV - the columns were separated by spaces not commas - so it's all peachy keen as far as I can tell.
 
When running a custom WeightedLexion of the structure,

index term weight category
1 a 1.46 concreteness
2 aardvark 4.68 concreteness
3 aback 1.65 concreteness
4 abacus 4.52 concreteness

`loeadWeightedLexiconFromSparse` was given an index out of bounds error on line 163.

This is the full stack track from the Colab notebook. Connecting to SQLite database: /content/sqlite_data/colab_csv.db Traceback (most recent call last):
  File "/usr/local/bin/dlatkInterface.py", line 2257, in <module>
    main()
  File "/usr/local/bin/dlatkInterface.py", line 1078, in main
    args.feattable = fe.addLexiconFeat(args.lextable, lowercase_only=args.lowercaseonly,
  File "/usr/local/lib/python3.10/dist-packages/dlatk/featureExtractor.py", line 1945, in addLexiconFeat
    lexiconTableName = self.load_lexicon(lexiconTableName)
  File "/usr/local/lib/python3.10/dist-packages/dlatk/dlaWorker.py", line 155, in load_lexicon
    self.lexicon.setWeightedLexicon(lex_to_func[lexicon_type](lexicon))
  File "/usr/local/lib/python3.10/dist-packages/dlatk/lexicainterface/lexInterface.py", line 163, in loadWeightedLexiconFromSparse
    cat = items[-2]
IndexError: list index out of range


I printed out `items` locally and see that it's list of length 1 because it's not being broken apart by space. By making this change, the string is split into a list of strings.

This is an example of a line 
`39954 zoom lens 4.81 concreteness` split into it's smaller parts
<img width="409" alt="Screenshot 2024-06-12 at 1 17 25 PM" src="https://github.com/dlatk/dlatk/assets/1661105/71d539c5-82d9-4546-8e54-da9c3ebc650b">
