### PR TITLE
Moving R import to local class where it is needed, so that rest of DLATK can be independent and work as is without R

### DIFF
--- a/dlatk/dimensionReducer.py
+++ b/dlatk/dimensionReducer.py
@@ -14,20 +14,6 @@ except ImportError:
     pass
 import pickle as pickle
 
-try:
-    from rpy2.robjects.packages import importr
-    import rpy2.robjects as ro
-    from rpy2.rinterface import RNULLType
-except ImportError:
-    try:
-        import readline
-        from rpy2.robjects.packages import importr
-        import rpy2.robjects as ro
-        from rpy2.rinterface import RNULLType
-    except ImportError:
-        pass
-    pass
-
 import pandas as pd
 
 try:
@@ -790,6 +776,20 @@ class CCA:
     """Handles CCA analyses of language and outcomes"""
 
     def __init__(self, fg, og, numComponents=15):
+        try:
+            from rpy2.robjects.packages import importr
+            import rpy2.robjects as ro
+            from rpy2.rinterface import RNULLType
+        except ImportError:
+            try:
+                import readline
+                from rpy2.robjects.packages import importr
+                import rpy2.robjects as ro
+                from rpy2.rinterface import RNULLType
+            except ImportError:
+                pass
+            pass
+
         try:
             import pandas.rpy.common as com
         except ImportError:


### PR DESCRIPTION
Bug:
With the current code as is, trying to import dlatk on a machine without R results in the following error: 
`Traceback (most recent call last): File "", line 1, in import rpy2.robjects as robjects File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/rpy2/robjects/init.py", line 16, in import rpy2.rinterface as rinterface File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/rpy2/rinterface/init.py", line 81, in """) RuntimeError: The R home directory could not be determined`

https://stackoverflow.com/questions/45769545/errors-about-r-home-when-importing-rpy2-submodule

The rpy2 import stems from https://github.com/dlatk/dlatk/blob/public/dlatk/dimensionReducer.py.

Although there is an exception handler to ignore "import errors", this path is not triggered in the above case as the exception raised is a Runtime error. There are two options: either ignore all exceptions, or move the irpy2 mport into the functions/classes that use R. I chose the latter.

