### PR TITLE
Stratify group and outcome - prefix version

### DIFF
--- a/dlatk/classifyPredictor.py
+++ b/dlatk/classifyPredictor.py
@@ -168,7 +168,7 @@ def computeAUC(ytrue, ypredProbs, multiclass=False, negatives=True, classes=None
     this_auc = 0.0
     if multiclass or len(classes) > 2:
         n_classes = len(classes)
-        ytrue = label_binarize(ytrue, classes=sorted(classes))
+        ytrue = label_binarize(ytrue, classes=sorted(classes))#<--why is this sorted?
 
         fpr = dict()
         tpr = dict()

--- a/dlatk/featureRefiner.py
+++ b/dlatk/featureRefiner.py
@@ -1034,7 +1034,7 @@ class FeatureRefiner(FeatureGetter):
         mm.disableTableKeys(self.corpdb, self.dbCursor, newTable, charset=self.encoding, use_unicode=self.use_unicode, mysql_config_file=self.mysql_config_file)
         
         dlac.warn("Inserting group_id, feat, and values")
-        sql = "INSERT INTO %s SELECT m.%s, f.feat, sum(f.value), 0 FROM %s AS f, %s AS m where m.%s = f.group_id GROUP BY m.%s, f.feat" % (newTable,self.correl_field, featureTable, self.corptable, oldGroupField, self.correl_field)
+        sql = "INSERT INTO %s (group_id, feat, value, group_norm) SELECT m.%s, f.feat, sum(f.value), 0 FROM %s AS f, %s AS m where m.%s = f.group_id GROUP BY m.%s, f.feat" % (newTable,self.correl_field, featureTable, self.corptable, oldGroupField, self.correl_field)
         mm.execute(self.corpdb, self.dbCursor, sql, charset=self.encoding, use_unicode=self.use_unicode, mysql_config_file=self.mysql_config_file)
 
         dlac.warn("Recalculating group_norms")

--- a/dlatk/regressionPredictor.py
+++ b/dlatk/regressionPredictor.py
@@ -3266,14 +3266,13 @@ def stratifyGroups(groups, outcomes, folds, randSortGroupsFirst = True, randomSt
     """
 
     #1. Check for super-groups, if so, change outcomes to their means by super group
-    #TODO
     if superGroups:
         oldOutcomes = outcomes
         outcomes = dict()
         for sg, subs_set in sg.items():
             outcomes[sg] = superGroupAvg([outcomes[gid] for gid in subs_set])
         oldGroups = groups
-        newGroups = superGroups.keys()
+        groups = superGroups.keys()
         
     #2. Sort by outcome 
     random.seed(randomState)
@@ -3283,7 +3282,7 @@ def stratifyGroups(groups, outcomes, folds, randSortGroupsFirst = True, randomSt
     outcome_groups = sorted(xGroups, key=lambda g: outcomes[g])
         
     #3. iterate to create groups per fold:
-    ##TOPDO: update to round robin:
+    ##TODO: update to round robin:
     groupsPerFold = {f: [] for f in range(folds)}
     # countPerFold = {f: 0 for f in range(folds)}
     for idx, grp in enumerate(outcome_groups):

--- a/dlatk/regressionPredictor.py
+++ b/dlatk/regressionPredictor.py
@@ -3255,29 +3255,41 @@ def foldN(l, folds):
         else: 
             yield l[i:i+n]
 
-def stratifyGroups(groups, outcomes, folds, randSortGroupsFirst = True, randomState=DEFAULT_RANDOM_SEED):
-    """breaks groups up into folds such that each fold has at most 1 more of a class than other folds """
+def stratifyGroups(groups, outcomes, folds, randSortGroupsFirst = True, randomState=DEFAULT_RANDOM_SEED, superGroups = None, superGroupAvg = lambda i: np.mean(i)):
+    """breaks groups up into folds such that each fold has at most 1 more of a class than other folds 
+    groups are the ids to be put into folds
+    outcomes are the outcomes to make sure are nearly uniform across folds
+    folds is the number of folds
+    randSortGroupsFirst makes sure the groups are randomly sorted before stratifying (in case they had an order already)
+    superGroups defines a higher order variable that groups belond such that a single super group; stratification is done by the average for the super group
+    superGroupAvg is the function to calculate the average (mean or median likely best)
+    """
+
+    #1. Check for super-groups, if so, change outcomes to their means by super group
+    #TODO
+    
+    #2. Sort by outcome 
     random.seed(randomState)
     xGroups = sorted(list(set(groups) & set(outcomes.keys())))
     if randSortGroupsFirst: #NOTE: this likely a good idea to always be true and remove sort above
         random.shuffle(xGroups) #to make sure starting random. 
-
-    # TODO: get rid of the following problem. DTypes should be fixed at the source. 
-    # outcome_values = [float(val) if not isinstance(val, float) or not isinstance(val, int) else val for val in list(outcomes.values())]
-    # outcome_groups = dict(zip(list(outcomes.keys()), outcome_values))
-    
     outcome_groups = sorted(xGroups, key=lambda g: outcomes[g])
         
+    #3. iterate to create groups per fold:
     groupsPerFold = {f: [] for f in range(folds)}
     # countPerFold = {f: 0 for f in range(folds)}
     for idx, grp in enumerate(outcome_groups):
         groupsPerFold[idx%folds].append(grp)
         
-    # make sure all outcomes aren't together in the groups:
+    #4.  make sure all outcomes aren't together in the groups:
     for gs in list(groupsPerFold.values()):
         random.shuffle(gs)
 
+    #5. If sorted by super-groups then project back to subordinate groups:
+    #TODO
+        
     return list(groupsPerFold.values())
+
 
 def hasMultValuesPerItem(listOfD):
     """returns true if the dictionary has a list with more than one element"""

--- a/dlatkInterface.py
+++ b/dlatkInterface.py
@@ -692,6 +692,8 @@ def main(fn_args = None):
                        help='Uses the classification coefficients to create a weighted lexicon.')
     group.add_argument('--stratify_folds', action='store_true', dest='stratifyfolds', default=False,
                        help='stratify folds during combo_test_classifiers or combo_test_regression')
+    group.add_argument('--prefix_super_groups', action='store_true', dest='prefixsupergroups', default=False,
+                       help='use group_id prefix as super group for stratify folds')
     group.add_argument('--train_c2r', action='store_true', dest='trainclasstoreg', default=False,
                        help='train a model that goes from classification to prediction')
     group.add_argument('--test_c2r', action='store_true', dest='testclasstoreg', default=False,
@@ -1900,7 +1902,7 @@ def main(fn_args = None):
                                            nFolds = args.folds, savePredictions = (args.pred_csv | args.prob_csv), weightedEvalOutcome = args.weightedeval,
                                            standardize = args.standardize, residualizedControls = args.res_controls, groupsWhere = args.groupswhere,
                                            weightedSample = args.weightedsample, adaptationFactorsName = args.adaptationfactors, featureSelectionParameters=args.featureselectionparams , factorSelectionType=args.factorselectiontype, numOfFactors=args.numoffactors, pairedFactors=args.pairedfactors, outputName = args.outputname, report=args.report, integrationMethod = args.integrationmethod,
-                                           stratifyFolds = args.stratifyfolds)
+                                               stratifyFolds = args.stratifyfolds, stratifyPrefixSuperGroups = args.prefixsupergroups)
         elif args.controladjustreg:
             comboScores = rp.adjustOutcomesFromControls(standardize = args.standardize, sparse = args.sparse,
                                                         allControlsOnly = args.allcontrolsonly, comboSizes = args.controlcombosizes,


### PR DESCRIPTION
adds --stratify_folds --prefix_super_groups For nfold test regression (testComboControls) this adds the ability to stratify such that a single super group is kept to a single fold (thus addressing an ecological fallacy when the groups being predicted aren't independent. For example, if has a dataset with users but outcomes are at a wave or message-level, use this to make sure users aren't in both the training and test set.  This is only the version that uses prefixes of group ids. It does not allow for any defined super group. 

Example Command: 
`
dlatkInterface.py -d states_and_traits -t msg_essays   -c user_wave_id -f 'feat$flan_t5_la_meL23con$msg_essays$user_wave_id' --outcome_table  outcomes_user_wave_2m2w  --group_freq_thresh 1  --outcomes openness_score --nfold_test_regression --model ridgehighcv --folds 5 --stratify_folds --prefix_super_groups
`