### PR TITLE
Fix: Incorrect/duplicate PCA Component feature naming in batched SQL while PCA reduction

### DIFF
--- a/dlatk/dimensionReducer.py
+++ b/dlatk/dimensionReducer.py
@@ -522,8 +522,9 @@ class DimensionReducer:
                     )
 
                     written = 0
-                    rows = []
+                    insert_batch_size = 60000
                     for feat in featNames:
+                        rows = []
                         preds = transformedX[outcomeName][feat]
 
                         print("[Inserting transformation as feature values for feature: %s]" % feat)
@@ -531,27 +532,28 @@ class DimensionReducer:
                         query = fe.qb.create_insert_query(featureTableName).set_values([("group_id",""),("feat",feat),("value",""),("group_norm","")])
                         for k, v in preds.items():
                             rows.append((k, v, v))
-                            if len(rows) >  60000 or len(rows) >= len(preds):
+                            if len(rows) >=  insert_batch_size: # or len(rows) >= len(preds):
                                 query.execute_query(rows)
                                 #mm.executeWriteMany(fe.corpdb, fe.dbCursor, wsql, rows, writeCursor=fe.dbConn.cursor(), charset=fe.encoding, use_unicode=fe.use_unicode, mysql_config_file=fe.mysql_config_file)
                                 written += len(rows)
                                 print("   %d feature rows written" % written)
                                 rows = []
-                    # if there's rows left
-                    if rows:
-                        # mm.executeWriteMany(
-                        #     fe.corpdb,
-                        #     fe.dbCursor,
-                        #     wsql,
-                        #     rows,
-                        #     writeCursor=fe.dbConn.cursor(),
-                        #     charset=fe.encoding,
-                        #     use_unicode=fe.use_unicode,
-                        # )
-                        #mm.executeWriteMany(fe.corpdb, fe.dbCursor, wsql, rows, writeCursor=fe.dbConn.cursor(), charset=fe.encoding, use_unicode=fe.use_unicode, mysql_config_file=fe.mysql_config_file)
-                        query.execute_query(rows)
-                        written += len(rows)
-                        print("   %d feature rows written" % written)
+                        # if there's rows left
+                        if rows:
+                            # mm.executeWriteMany(
+                            #     fe.corpdb,
+                            #     fe.dbCursor,
+                            #     wsql,
+                            #     rows,
+                            #     writeCursor=fe.dbConn.cursor(),
+                            #     charset=fe.encoding,
+                            #     use_unicode=fe.use_unicode,
+                            # )
+                            #mm.executeWriteMany(fe.corpdb, fe.dbCursor, wsql, rows, writeCursor=fe.dbConn.cursor(), charset=fe.encoding, use_unicode=fe.use_unicode, mysql_config_file=fe.mysql_config_file)
+                            query.execute_query(rows)
+                            written += len(rows)
+                            print("   %d feature rows written" % written)
+                            print("[Finished Inserting for feature: %s]" % feat)
                     fTables.append(featureTableName)
 
             else:


### PR DESCRIPTION
Issue:
When performing PCA reduction on a feature table, the resulting SQL output contained duplicate and incorrect PCA component feature names across group_ids, even though the actual PCA values were distinct.
For example:
- Only initial group_ids were assigned to COMPONENT_0
- Later entries were incorrectly labeled as COMPONENT_1 or COMPONENT_2
This led to an imbalanced distribution of PCA component features, with some components missing or overrepresented. 

Root Cause:
The dimensionReducer.py script inserts PCA components into the SQL table in batches of 60,000 rows. However, the logic to flush the remaining (non-batched) rows was mistakenly placed outside the loop that processes each PCA component.
As a result, leftover rows from earlier components were not properly inserted and were instead carried over to the next component. Ultimately, all remaining rows ended up being inserted under the last PCA component (COMPONENT_n-1), leading to incorrect and unbalanced feature distributions.
This issue only occurred when the message table contained more than 60,000 groups — smaller tables were unaffected.

Fix:
Moved the logic for flushing remaining rows inside the loop that iterates through PCA components.
This ensures that all PCA component values are inserted into their respective COMPONENT_* features, regardless of batch size.