### PR TITLE
Merging Sentence Transformer and created a unit test for sentence transformer 

### DIFF
--- a/dlatk/dlaConstants.py
+++ b/dlatk/dlaConstants.py
@@ -138,6 +138,7 @@ DEF_EMB_MODEL='bert-base-uncased'
 DEF_EMB_AGGREGATION=['mean']
 DEF_EMB_LAYER_AGGREGATION=['concatenate']
 DEF_EMB_LAYERS=[-2]
+DEF_SENT_EMB_LAYERS=[-1]
 DEF_TRANS_WORD_AGGREGATION = ['mean']
 GPU_BATCH_SIZE = 32
 EMB_OPTIONS = ['bert-base-uncased', 'bert-large-uncased', 'bert-base-cased', 'bert-large-cased', 'SpanBERT/spanbert-base-cased', 'SpanBERT/spanbert-large-cased', 

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1579,7 +1579,379 @@ class FeatureExtractor(DLAWorker):
         dlac.warn("Adding Keys (if goes to keycache, then decrease MAX_TO_DISABLE_KEYS or run myisamchk -n).")
         self.data_engine.enable_table_keys(embTableName)#rebuilds keys
         dlac.warn("Done\n")
-        return embTableName;       
+        return embTableName;  
+
+
+
+    def addSentenceEmbTable(self, modelName, tokenizerName, modelClass=None, batchSize=dlac.GPU_BATCH_SIZE, aggregations = ['mean'], layersToKeep = [8,9,10,11], maxTokensPerSeg=255, noContext=True, layerAggregations = ['concatenate'], wordAggregations = ['mean'], keepMsgFeats = False, customTableName = None, valueFunc = lambda d: d):
+        '''
+            Adds transformer embeddings
+            ---------------------------
+            Args:
+                modelName (str): model name or path of transformer (huggingface supported) model
+                tokenizerName (str): tokenizer name or path of the tokenizer (huggingface supported)
+                modelClass (str): The model class of the transformer model
+                aggregations (List[str]): Aggregation to apply on correl field level
+                layersToKeep (List[int]): Transformer Layers to extract the embeddings from
+                layerAggregations (List[str]): Aggregation to apply over transformer layers' representations
+                keepMsgFeats (bool): Store message level transformer representations
+                customTableName (str): custom feature table name (if None, then it will be generated automatically)
+                batchSize (int): batch size for GPU processing
+        '''
+        
+        def parse_layers(layers, num_hidden_layers):
+            """
+                Checks the validity of the input layer number
+                Turns negative layer idx into equivalent positive and sorts layer numbers in ascending order
+            """
+            for lyr in layers:
+                if (lyr > num_hidden_layers):
+                    print ("You have supplied a layer number %s greater than the total number of layers (%s) in the model. Retry with valid layer number(s)."%(lyr, num_hidden_layers))
+                    sys.exit()
+
+            layers = [(lyr%num_hidden_layers)+1 if lyr<0 else lyr for lyr in layers]
+            #removing duplicate layer inputs
+            layers = sorted(list(set(layers)))
+
+            return layers
+        
+        def addSentTokenized(messageRows):
+
+            try:
+                import nltk.data
+                import sys
+            except ImportError:
+                print("warning: unable to import nltk.tree or nltk.corpus or nltk.data")
+            sentDetector = nltk.data.load('tokenizers/punkt/english.pickle')
+            messages = list(map(lambda x: x[1], messageRows))
+            parses = []
+            for m_id, message in messageRows:
+                if message is not None: parses.append([m_id, json.dumps(sentDetector.tokenize(tc.removeNonUTF8(tc.treatNewlines(message.strip()))))])
+            return parses
+
+        dlac.warn("WARNING: new version of BERT and transformer models starts at layer 1 rather than layer 0. Layer 0 is now the input embedding. For example, if you were using layer 10 for the second to last layer of bert-base that is now considered layer 11.")
+        ##FIRST MAKE SURE SENTENCE TOKENIZED TABLE EXISTS:
+        #sentTable = self.corptable+'_stoks' 
+        #assert mm.tableExists(self.corpdb, self.dbCursor, sentTable, charset=self.encoding, use_unicode=self.use_unicode), "Need %s table to proceed with Bert featrue extraction (run --add_sent_tokenized)" % sentTable
+        
+        sentTok_onthefly = False if self.data_engine.tableExists(self.corptable+'_stoks') else True
+        sentTable = self.corptable if sentTok_onthefly else self.corptable+'_stoks'
+        if sentTok_onthefly: dlac.warn("WARNING: run --add_sent_tokenized on the message table to avoid tokenizing it every time you generate embeddings")
+        
+        #if len(layerAggregations) > 1:
+        #    dlac.warn("AddBert: !!Does not currently support more than one layer aggregation; only using first aggregation!!")
+        #    layerAggregations = layerAggregations[:1]
+
+        tokenizerName = modelName if tokenizerName is None else tokenizerName
+        
+        try: 
+            import torch
+            from torch.nn.utils.rnn import pad_sequence
+            from transformers import AutoConfig, AutoModel, AutoTokenizer
+            from transformers import TransfoXLTokenizer, TransfoXLModel, BertModel, BertTokenizer, OpenAIGPTModel, OpenAIGPTTokenizer
+            from transformers import GPT2Model, GPT2Tokenizer, XLNetModel, XLNetTokenizer, DistilBertModel, DistilBertTokenizer
+            from transformers import RobertaModel, RobertaTokenizer, XLMModel, XLMTokenizer, XLMRobertaModel, XLMRobertaTokenizer
+            from transformers import AlbertModel, AlbertTokenizer, T5Model, T5Tokenizer
+            from sentence_transformers import SentenceTransformer
+
+            #from transformers import ElectraModel, ElectraTokenizer
+        except ImportError:
+           dlac.warn("warning: unable to import torch or transformers")
+           dlac.warn("Please install pytorch and transformers.")
+           sys.exit(1)
+
+        SHORTHAND_DICT = { 'bert-base-uncased': 'bert', 'bert-large-uncased': 'bert', 'bert-base-cased': 'bert', 'bert-large-cased': 'bert',
+                            'SpanBERT/spanbert-base-cased': 'bert', 'SpanBERT/spanbert-large-cased': 'bert',
+                            'allenai/scibert_scivocab_cased': 'bert', 'allenai/scibert_scivocab_uncased': 'bert',# 'transfo-xl-wt103': 'transfoXL',
+                            #'openai-gpt': 'OpenAIGPT', 
+                            'gpt2': 'GPT2', 'gpt2-medium': 'GPT2', 'gpt2-large': 'GPT2', 'gpt2-xl': 'GPT2',
+                            'xlnet-base-cased': 'XLNet', 'xlnet-large-cased': 'XLNet',
+                            'roberta-base': 'Roberta', 'roberta-large': 'Roberta', 'roberta-large-mnli': 'Roberta', 
+                            'distilroberta-base': 'Roberta', 'roberta-base-openai-detector': 'Roberta', 'roberta-large-openai-detector': 'Roberta',
+                            'distilbert-base-uncased': 'DistilBert', 'distilbert-base-cased': 'DistilBert', 
+                            'distilbert-base-multilingual-cased': 'DistilBert', 'distilbert-base-cased-distilled-squad': 'DistilBert',
+                            'albert-base-v2': 'Albert', 'albert-large-v2': 'Albert', 'albert-xlarge-v2': 'Albert', 'albert-xxlarge-v2': 'Albert',
+                            'xlm-roberta-base': 'XLMRoberta', 'xlm-roberta-large': 'XLMRoberta', #'t5-small': 'T5', 't5-base': 'T5', 't5-large': 'T5', 
+                            'mxbai-embed-large-v1': 'auto',
+        }
+
+        MODEL_DICT = {
+            #'transfoXL': [TransfoXLModel, TransfoXLTokenizer], #Need to look into tokenization
+            'auto': [AutoModel, AutoTokenizer],
+            'bert' : [BertModel, BertTokenizer],
+            'XLNet': [XLNetModel, XLNetTokenizer], 
+            #'OpenAIGPT': [OpenAIGPTModel,  OpenAIGPTTokenizer], # Need to fix tokenization [Token type Ids], Doesn't have CLS or SEP
+            'Roberta': [RobertaModel, RobertaTokenizer], # Need to fix tokenization [Token type Ids]
+            'GPT2': [GPT2Model, GPT2Tokenizer], # Need to fix tokenization [Token type Ids], Doesn't have CLS or SEP
+            'DistilBert': [DistilBertModel, DistilBertTokenizer], #Doesn't take Token Type IDS as input
+            #'XLM': [XLMModel, XLMTokenizer], #Need to decide on the specific models
+            'XLMRoberta': [XLMRobertaModel, XLMRobertaTokenizer],  # Need to fix tokenization [Token type Ids]
+            'Albert': [AlbertModel, AlbertTokenizer],
+            #'Electra': [ElectraModel, ElectraTokenizer], #Need to understand the discriminator and generator outputs better
+            #'T5': [T5Model, T5Tokenizer] #Doesn't take Token Type IDS as input, Doesn't have CLS or SEP, Need to understand how to input the decoder_input_ids/decoder_inputs_embeds
+        }
+
+        #print (modelName) #debug
+        #Fix AutoModel, runs into a weird positional embedding issue right now.
+        #config = AutoConfig.from_pretrained(modelName, output_hidden_states=True)
+        #tokenizer = AutoTokenizer.from_pretrained(tokenizerName)
+        #model = AutoModel.from_pretrained(modelName, config=config)
+
+
+
+        if modelClass is not None: 
+            #tokenizer = MODEL_DICT[modelClass][1].from_pretrained(tokenizerName)
+            #model = MODEL_DICT[modelClass][0].from_pretrained(modelName, output_hidden_states=True)
+            model = SentenceTransformer('all-MiniLM-L6-v2')
+        else:
+            tokenizer = MODEL_DICT[SHORTHAND_DICT[tokenizerName]][1].from_pretrained(tokenizerName)
+            model = MODEL_DICT[SHORTHAND_DICT[modelName]][0].from_pretrained(modelName, output_hidden_states=True)
+
+        model = SentenceTransformer('all-MiniLM-L6-v2')
+
+        maxTokensPerSeg = tokenizer.max_len_sentences_pair//2
+        #Fix for gpt2
+        pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id else 0
+        model.eval()
+        cuda = True
+        try:
+            model.to('cuda')
+            batch_size=batchSize
+        except:
+            dlac.warn(" unable to use CUDA (GPU) for BERT")
+            batch_size=batchSize
+            cuda = False
+        dlac.warn("Done.")
+
+        # Access the transformer model (which is based on Hugging Face's transformer models)
+        layersToKeep = parse_layers(layersToKeep, model[0].auto_model.config.num_hidden_layers)
+        layersToKeep = np.array(layersToKeep, dtype='int')
+
+        #TODO: Change the model name later
+        #Need to test noc
+        noc = ''
+        if noContext: noc = 'noc_'#adds noc to name if no context
+        if customTableName is None:
+            modelName = modelName.split('/')[-1] if '/' in modelName else modelName
+            modelPieces = modelName.split('-')
+            modelNameShort = modelPieces[0] + '_' + '_'.join([s[:2] for s in modelPieces[1:]])\
+                            + '_' + noc+''.join([str(ag[:2]) for ag in aggregations])+'L'+'L'.join([str(l) for l in layersToKeep])+''.join([str(ag[:2]) for ag in layerAggregations]) + 'n'
+        else:
+            modelNameShort = customTableName
+        if keepMsgFeats:
+            embTableName = self.createFeatureTable(modelNameShort, "VARCHAR(12)", 'DOUBLE', None, valueFunc, correlField='message_id')
+        else:
+            embTableName = self.createFeatureTable(modelNameShort, "VARCHAR(12)", 'DOUBLE', None, valueFunc)
+
+        #SELECT / LOOP ON CORREL FIELD FIRST:
+        usql = """SELECT %s FROM %s GROUP BY %s""" % (self.correl_field, sentTable, self.correl_field)
+        msgs = 0#keeps track of the number of messages read
+        cfRows = FeatureExtractor.noneToNull(self.data_engine.execute_get_list(usql))#SSCursor woudl be better, but it loses connection
+
+        ##iterate through correl_ids (group id):
+        dlac.warn("finding messages for %d '%s's"%(len(cfRows), self.correl_field))
+        self.data_engine.disable_table_keys(embTableName)#for faster, when enough space for repair by sorting
+        lengthWarned = False #whether the length warning has been printed yet
+        #Each User: ( #message aggregations, #layers, #Word aggregations, hidden size)
+        for cfRow in cfRows:
+            #user_id
+            cf_id = cfRow[0]
+            mids = set() #currently seen message ids
+            midList = [] #only for keepMsgFeats
+
+            #grab sents by messages for that correl field:
+            messageRows = self.getMessagesForCorrelField(cf_id, messageTable = sentTable, warnMsg=True)
+            if sentTok_onthefly:
+                messageRows = addSentTokenized(messageRows)
+            input_sents = []
+            token_type_ids = []
+            attention_mask = []
+            message_id_seq = [] 
+            #stores the sequence of message_id corresponding to the message embeddings for applying aggregation later 
+            #along with the sentence 1 and sentence 2 lengths
+            for messageRow in messageRows:
+                message_id = messageRow[0]
+                try:
+                    messageSents = loads(messageRow[1])
+                except NameError: 
+                    dlac.warn("Error: Cannot import jsonrpclib or simplejson in order to get sentences for Bert")
+                    sys.exit(1)
+                except json.JSONDecodeError:
+                    dlac.warn("WARNING: JSONDecodeError on %s. Skipping Message"%str(messageRow))
+                    continue
+                except:
+                    dlac.warn("Warning: cannot load message, skipping")
+                    continue
+
+                if ((message_id not in mids) and (len(messageSents) > 0)):
+                    msgs+=1
+                    subMessages=[messageSents]
+
+                    i = 0
+
+                    for i in range(len(messageSents)):
+                        #TODO: preprocess to remove newlines
+                        #sentsTok = [tokenizer.tokenize(s) for s in sents]
+                        #print(sents)#debug
+                        #check for overlength:
+                        
+                        thisSentPair = " ".join(messageSents[i:i+2]) #Give two sequences as input
+                        input_sents.append(thisSentPair)
+                        if i<(len(messageSents)-1): #Collecting the sentence length of the pair along with their message IDs
+                            # If multiple sentences in a message, it will store the message_ids multiple times for aggregating emb later.
+                            message_id_seq.append([message_id, len(messageSents[i]), len(messageSents[i+1])]) 
+                        else:
+                            message_id_seq.append([message_id, len(messageSents[i]), 0])
+                        #for single sentence
+                        #message_id_seq.extend([[message_id, len(string)] for string in input_sents])
+                
+                if msgs % int(dlac.PROGRESS_AFTER_ROWS/5) == 0: #progress update
+                    dlac.warn("Messages Read: %.2f k" % (msgs/1000.0))
+                mids.add(message_id)
+                midList.append(message_id)
+            
+            #Number of Batches
+            num_batches = int(np.ceil(len(input_sents)/batch_size))
+            encSelectLayers = []
+            #print ('len(input_ids): ',len(input_ids))
+            #print ('Num Batches:', num_batches)
+            #TODO: Check if len(messageSents) = 0, skip this and print warning
+            for i in range(num_batches):
+                
+                #print (input_ids_padded.shape, token_type_ids_padded.shape, attention_mask_padded.shape)
+                encSelectLayers_temp = []
+
+                print("DEBUG: ", type(input_sents))
+                print("DEBUG: ", input_sents[0])
+                print("DEBUG Batch: ", batch_size)
+                #print("DEBUG Batch: ", input_sents[i*batch_size:(i+1)*batch_size])
+                with torch.no_grad():
+                    # embeddings = model.encode(input_sents[i*batch_size:(i+1)*batch_size], device='cuda')
+                    embeddings = model.encode(input_sents[i*batch_size:(i+1)*batch_size], device='cuda')
+
+                    #Getting all layers output
+                    #encAllLayers = encAllLayers[-1]            
+                    #for lyr in layersToKeep: #Shape: (batch_size, max Seq len, hidden dim, #layers)
+                    #    encSelectLayers_temp.append(encAllLayers[int(lyr)].detach().cpu().numpy())
+                    print("SHAPE: ", embeddings.shape)
+                    
+                #encSelectLayers.append(np.transpose(np.array(embeddings),(1,2,3,0)))
+                encSelectLayers.append(np.array(embeddings)) #Shape= batch_size, embedding size (32, 384)
+
+            i = 0
+            j = 0
+            msg_rep = [] #Shape: (num layers, seq Len, hidden_dim)
+            while i < len(message_id_seq):
+                # Does next embedding also pertain to the same message
+                if i == len(message_id_seq)-1:
+                    next_msg_same = False
+                else:
+                    next_msg_same = True if message_id_seq[i][0] == message_id_seq[i+1][0] else False
+                if next_msg_same:
+                    # Process all sub messages pertaining to a single message at once
+                    msg_rep_temp = []
+                    # Store the first message's first sentence embedding followed by averaging the second sentence of that message and the first sentence of next message's embedding   
+                    msg_rep_temp.append(encSelectLayers[i//batch_size][j%batch_size, :message_id_seq[i][1]])
+                    while next_msg_same:
+                        enc_batch_number = i//batch_size
+                        next_enc_batch_number = (i+1)//batch_size
+                        seq_len1 = message_id_seq[i][1]
+                        seq_len2 = message_id_seq[i][2]
+                        #Shape: (seq2 len, hidden dim, num layers)
+                        #Apply mean for the embedding of the sentence that appeared second in the current part and first in the next part
+                        print("AARON DEBUG: ", encSelectLayers[enc_batch_number][j%batch_size, seq_len1:seq_len1+seq_len2].shape)
+                        print("AARON DEBUG: ", encSelectLayers[next_enc_batch_number][(j+1)%batch_size, :seq_len2].shape)
+                        print("AARON DEBUG1: ", seq_len1)
+                        print("AARON DEBUG2: ", seq_len2)
+                        for p in encSelectLayers[1]:
+                            print("AARON DEBUG SHAPE: ", p.shape)
+                        sent2enc = (encSelectLayers[enc_batch_number][j%batch_size, seq_len1:seq_len1+seq_len2] + encSelectLayers[next_enc_batch_number][(j+1)%batch_size, :seq_len2])/2
+                        #Store the representation
+                        msg_rep_temp.append(sent2enc)
+                        #print (message_id_seq[i], sent2enc.shape) #debug
+                        i+=1
+                        j+=1
+                        #Check if the next part of the message has single sentence, if yes, break 
+                        if message_id_seq[i][2] == 0:
+                            i+=1
+                            j+=1
+                            break                        
+                        next_msg_same = True if message_id_seq[i][0] == message_id_seq[i+1][0] else False
+                    #Store all the representation as a list
+                    msg_rep.append(msg_rep_temp)
+                else:
+                    # Single message representations.
+                    enc_batch_number = i//batch_size
+                    seq_len = message_id_seq[i][1]
+                    #Store the message representation
+                    msg_rep_temp = encSelectLayers[enc_batch_number][j%batch_size, :seq_len] #Shape: (seq len, hidden dim, #layers)
+                    #print (seq_len, msg_rep_temp.shape) #debug
+                    i+=1
+                    j+=1
+                    msg_rep.append([msg_rep_temp])
+
+            #Layer aggregation followed by word aggregation
+            user_rep = [] #(num msgs, hidden_dim, lagg)
+            for i in range(len(msg_rep)):#Iterating through messages
+                sent_rep = []
+                for j in range(len(msg_rep[i])): #Iterate through the submessages to apply layer aggregation. 
+                    sub_msg = msg_rep[i][j]
+                    sub_msg_lagg = []
+                    for lagg in layerAggregations:
+                        if lagg == 'concatenate':
+                            sub_msg_lagg.append(sub_msg) #(seq len, hidden dim, num layers)
+                        else:
+                            sub_msg_lagg.append(eval("np."+lagg+"(sub_msg, axis=-1)").reshape(sub_msg.shape[0], sub_msg.shape[1], 1) )#(seq len, hidden dim, 1)
+                        #Shape: (seq len, hidden dim, (num_layers*(concatenate==True)+(sum(other layer aggregations))))
+                        #Example: lagg = [mean, min, concatenate], layers = [8,9]; Shape: (seq len, hidden dim, 2 + 1 + 1)
+                        sub_msg_lagg_ = np.concatenate(sub_msg_lagg, axis=-1) 
+                    #Getting the mean of all tokens representation
+                    #TODO: add word agg list and do eval
+                    sub_msg_lagg_wagg = np.mean(sub_msg_lagg_, axis=0) #Shape: (hidden dim, lagg)
+                    #ReShaping: (1, hidden dim, lagg)
+                    sub_msg_lagg_wagg = sub_msg_lagg_wagg.reshape(1, sub_msg_lagg_wagg.shape[0], sub_msg_lagg_wagg.shape[1]) 
+                    #Sentence representations
+                    sent_rep.append(sub_msg_lagg_wagg)
+                #Accumulate all the sentence representation of a user
+                user_rep.append(np.mean(np.concatenate(sent_rep, axis=0), axis=0)) 
+
+            user_rep = np.array(user_rep)
+            if user_rep.shape[0] == 0:
+                continue
+            #Flatten the features [layer aggregations] to a single dimension.
+            user_rep = user_rep.reshape(user_rep.shape[0], -1)
+            if len(user_rep)>0:
+                embFeats = dict()
+
+                if keepMsgFeats: #just store message embeddings
+                    embRows = []
+                    for mid, msg in zip(midList, user_rep):
+                        embRows.extend([(str(mid), str(k), v, valueFunc(v)) for (k, v) in enumerate(msg)])
+                    wsql = """INSERT INTO """+embTableName+""" (group_id, feat, value, group_norm) values (%s, %s, %s, %s)"""
+                    mm.executeWriteMany(self.corpdb, self.dbCursor, wsql, embRows, writeCursor=self.dbConn.cursor(), charset=self.encoding, use_unicode=self.use_unicode, mysql_config_file=self.mysql_config_file)
+                    
+                else:#Applying message aggregations
+                    for ag in aggregations:
+                        thisAg = eval("np."+ag+"(user_rep, axis=0)")
+                        embFeats.update([(str(k)+ag[:2], v) for (k, v) in enumerate(thisAg)])
+                
+                        #wsql = """INSERT INTO """+embTableName+""" (group_id, feat, value, group_norm) values ('"""+str(cf_id)+"""', %s, %s, %s)"""
+                        insert_idx_start = 0
+                        insert_idx_end = dlac.MYSQL_BATCH_INSERT_SIZE
+                        query = self.qb.create_insert_query(embTableName).set_values([("group_id",str(cf_id)),("feat",""),("value",""),("group_norm","")])
+                        embRows = [(k, float(v), valueFunc(float(v))) for k, v in embFeats.items()] #adds group_norm and applies freq filter
+                        while insert_idx_start < len(embRows):
+                            insert_rows = embRows[insert_idx_start:min(insert_idx_end, len(embRows))]
+                            query.execute_query(insert_rows)
+                            insert_idx_start += dlac.MYSQL_BATCH_INSERT_SIZE
+                            insert_idx_end += dlac.MYSQL_BATCH_INSERT_SIZE
+                        #self.data_engine.execute_write_many(wsql, embRows)
+            
+        dlac.warn("Done Reading / Inserting.")
+        dlac.warn("Adding Keys (if goes to keycache, then decrease MAX_TO_DISABLE_KEYS or run myisamchk -n).")
+        self.data_engine.enable_table_keys(embTableName)#rebuilds keys
+        dlac.warn("Done\n")
+        return embTableName;     
 
     
     def addFleschKincaidTable(self, tableName = None, valueFunc = lambda d: d, removeXML = True, removeURL = True):

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1657,7 +1657,9 @@ class FeatureExtractor(DLAWorker):
            dlac.warn("Please install pytorch and transformers and sentence_transformers.")
            sys.exit(1)
 
-        tokenizer = AutoTokenizer.from_pretrained(modelName)
+
+        tokenizerName = modelName if tokenizerName is None else tokenizerName
+        tokenizer = AutoTokenizer.from_pretrained(tokenizerName)
         model = SentenceTransformer(modelName)
 
         #Fix for gpt2

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1760,10 +1760,12 @@ class FeatureExtractor(DLAWorker):
             #Number of Batches
             num_batches = int(np.ceil(len(input_sents)/batch_size))
             encSelectLayers = []
-
             transformer = model[0].auto_model
             pooling_layer = model[1]
-            normalize_layer = model[2]
+            try:
+                normalize_layer = model[2]
+            except:
+                pass
         
 
 
@@ -1784,10 +1786,13 @@ class FeatureExtractor(DLAWorker):
                 
                 for lyr in layersToKeep:
                     # Apply pooling
-                    pooled_emb = pooling_layer({"token_embeddings": hidden_states[lyr], "attention_mask": attention_mask_padded})
+                    emb = pooling_layer({"token_embeddings": hidden_states[lyr], "attention_mask": attention_mask_padded})
                     # Apply normalization
-                    normalized_emb = normalize_layer(pooled_emb)
-                    encSelectLayers_temp.append(normalized_emb["sentence_embedding"].detach().cpu().numpy())
+                    try:
+                        emb = normalize_layer(emb)
+                    except:
+                        pass
+                    encSelectLayers_temp.append(emb["sentence_embedding"].detach().cpu().numpy())
 
                 encSelectLayers.append(np.transpose(np.array(encSelectLayers_temp),(1,2,0)))
 

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1673,6 +1673,8 @@ class FeatureExtractor(DLAWorker):
            dlac.warn("Please install pytorch and transformers and sentence_transformers.")
            sys.exit(1)
 
+        if layersToKeep != [-1]:
+            dlac.warn("WARNING: you are taking embeddings from layer(s) other than the final layer, SentenceTransformer cosine similarity may not be preserved")
 
         tokenizerName = modelName if tokenizerName is None else tokenizerName
         tokenizer = AutoTokenizer.from_pretrained(tokenizerName)

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1622,14 +1622,26 @@ class FeatureExtractor(DLAWorker):
         def tokenizeWithLengthWarning(text, tokenizer):
             nonlocal sentTruncationWarning
             max_length = tokenizer.model_max_length
-            
-            tokens = tokenizer(
-                text,
-                return_tensors="pt",
-                truncation=True,
-                max_length=max_length,
-            ).to('cuda')
-
+            if max_length > 1_000_000:  # arbitrary large sentinel cutoff
+                max_length = 512
+            try: 
+                tokens = tokenizer(
+                    text,
+                    return_tensors="pt",
+                    truncation=True,
+                    max_length=max_length,
+                ).to('cuda')
+            except OverflowError:
+                print("=== OVERFLOW DETECTED ===")
+                print(f"Type: {type(text)}")
+                if isinstance(text, list):
+                    for idx, t in enumerate(text):
+                        print(f"[{idx}] Length (chars): {len(t)}")
+                        print(f"Content preview: {t[:500]}{'...' if len(t) > 500 else ''}")
+                else:
+                    print(f"Length (chars): {len(text)}")
+                    print(f"Content preview: {text[:500]}{'...' if len(text) > 500 else ''}")
+                raise
             if not sentTruncationWarning:
                 # Check if truncation occurred
                 num_tokens = len(tokenizer.encode(text, add_special_tokens=True))

--- a/dlatk/featureExtractor.py
+++ b/dlatk/featureExtractor.py
@@ -1743,21 +1743,37 @@ class FeatureExtractor(DLAWorker):
             #stores the sequence of message_id corresponding to the message embeddings for applying aggregation later 
             for messageRow in messageRows:
                 message_id = messageRow[0]
-                messageSent = messageRow[1]
 
-                if ((message_id not in mids) and (len(messageSent) > 0)):
+                try:
+                    messageSents = loads(messageRow[1])
+                except NameError: 
+                    dlac.warn("Error: Cannot import jsonrpclib or simplejson in order to get sentences for Bert")
+                    sys.exit(1)
+                except json.JSONDecodeError:
+                    dlac.warn("WARNING: JSONDecodeError on %s. Skipping Message"%str(messageRow))
+                    continue
+                except:
+                    dlac.warn("Warning: cannot load message, skipping")
+                    continue
+
+                if ((message_id not in mids) and (len(messageSents) > 0)):
                     msgs+=1
                     i = 0
-                    tokens = tokenizeWithLengthWarning(messageSent, tokenizer)
+                    messageSents = ' '.join(messageSents)
+                    tokens = tokenizeWithLengthWarning(messageSents, tokenizer)
                     input_sents.append(torch.tensor(tokens['input_ids'], dtype=torch.long).squeeze(0))
                     attention_mask.append(tokens['attention_mask'].squeeze(0))
                     message_id_seq.append([message_id, len(tokens)])
+
                 
                 if msgs % int(dlac.PROGRESS_AFTER_ROWS/5) == 0: #progress update
                     dlac.warn("Messages Read: %.2f k" % (msgs/1000.0))
                 mids.add(message_id)
                 midList.append(message_id)
             
+            if(input_sents == []):
+                dlac.warn("Warning: Empty message")
+                continue
 
             #Number of Batches
             num_batches = int(np.ceil(len(input_sents)/batch_size))

--- a/dlatkInterface.py
+++ b/dlatkInterface.py
@@ -490,6 +490,8 @@ def main(fn_args = None):
                        help='add an people names feature table. (two agrs: NAMES_LEX, ENGLISH_LEX, can flag: sqrt)')
     group.add_argument('--add_embedding', '--add_emb_feat',  '--add_bert', action='store_true', dest='embaddfeat',
                        help='add BERT mean features (optionally add min, max, --bert_model large)')
+    group.add_argument('--add_sentence_embedding', '--add_sent_emb_feat',  '--add_sbert', action='store_true', dest='sembaddfeat',
+                       help='add sBERT mean features (optionally add min, max, --bert_model large)')
     group.add_argument('--lexicon_normalization', '--lex_norm', '--dict_norm', action='store_true', help='Use weighting over lexicon terms (instead of over all terms).')
     group.add_argument('--multicategory_normalization', '--liwc_normalization', '--liwc_norm', action='store_true', help='Use weighting over lexicon terms across terms in all categories. Similar to --lexicon_normalization but totals are across all lexicon categories.')
 
@@ -1101,6 +1103,11 @@ def main(fn_args = None):
         if not fe: fe = FE()
         args.feattable = fe.addEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
     
+    if args.sembaddfeat:
+        if not fe: fe = FE()
+        args.feattable = fe.addSentenceEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
+    
+
     if args.addldafeattable:
         if not fe: fe = FE()
         args.feattable = fe.addLDAFeatTable(args.addldafeattable, valueFunc = args.valuefunc)

--- a/dlatkInterface.py
+++ b/dlatkInterface.py
@@ -222,7 +222,7 @@ def main(fn_args = None):
                        help='Aggregations to use with Contextual embedding model (e.g. mean, min, max).')
     group.add_argument('--embedding_word_aggregation', '--word_aggregation', '--bert_word_aggregation', type=str, metavar='AGG', nargs='+', dest='transwordaggs', default=dlac.DEF_TRANS_WORD_AGGREGATION,
                        help='Aggregations to use for words (e.g. mean or concatenate).')
-    group.add_argument('--embedding_layers', '--emb_layers', '--bert_layers', type=int, metavar='LAYER', nargs='+', dest='emblayers', default=dlac.DEF_EMB_LAYERS,
+    group.add_argument('--embedding_layers', '--emb_layers', '--bert_layers', type=int, metavar='LAYER', nargs='+', dest='emblayers', default=None,
                        help='layers from Contextual model to keep.')
     group.add_argument('--embedding_no_context', '--emb_no_context', '--bert_no_context', action='store_true', dest='embnocontext', default=False,
                        help='encoded without considering context.')
@@ -490,7 +490,7 @@ def main(fn_args = None):
                        help='add an people names feature table. (two agrs: NAMES_LEX, ENGLISH_LEX, can flag: sqrt)')
     group.add_argument('--add_embedding', '--add_emb_feat',  '--add_bert', action='store_true', dest='embaddfeat',
                        help='add BERT mean features (optionally add min, max, --bert_model large)')
-    group.add_argument('--add_sentence_embedding', '--add_sent_emb_feat',  '--add_sbert', action='store_true', dest='sembaddfeat',
+    group.add_argument('--add_sentence_embedding', '--add_sent_emb_feat',  '--add_sbert', '--add_cosine_emb', '--add_msg_emb', action='store_true', dest='sembaddfeat',
                        help='add sBERT mean features (optionally add min, max, --bert_model large)')
     group.add_argument('--lexicon_normalization', '--lex_norm', '--dict_norm', action='store_true', help='Use weighting over lexicon terms (instead of over all terms).')
     group.add_argument('--multicategory_normalization', '--liwc_normalization', '--liwc_norm', action='store_true', help='Use weighting over lexicon terms across terms in all categories. Similar to --lexicon_normalization but totals are across all lexicon categories.')
@@ -1101,11 +1101,11 @@ def main(fn_args = None):
 
     if args.embaddfeat:
         if not fe: fe = FE()
-        args.feattable = fe.addEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
+        args.feattable = fe.addEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers if args.emblayers else dlac.DEF_EMB_LAYERS, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
     
     if args.sembaddfeat:
         if not fe: fe = FE()
-        args.feattable = fe.addSentenceEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
+        args.feattable = fe.addSentenceEmbTable(modelName = args.embmodel, tokenizerName=args.tokenizermodel, modelClass = args.embclass, batchSize=args.batchsize, aggregations=args.embaggs, layersToKeep=args.emblayers if args.emblayers else dlac.DEF_SENT_EMB_LAYERS, noContext=args.embnocontext, layerAggregations = args.emblayeraggs, wordAggregations=args.transwordaggs, valueFunc = args.valuefunc, customTableName = args.embtablename, keepMsgFeats = args.embkeepmsg)
     
 
     if args.addldafeattable:

--- a/doc/source/tutorials/tut_bert.rst
+++ b/doc/source/tutorials/tut_bert.rst
@@ -200,3 +200,22 @@ There's a natural question we've glossed over here: what exactly do the BERT fea
         +----+----------+------+-----------------------+-----------------------+
 
 The names of the ``feat`` column may seem a bit opaque at first, but they are simple to interpret: the number indicates the index of the dimension in the BERT embedding vector, while the ``me`` indicates that the message embeddings were aggregated using the mean. If you have specified multiple message aggregations, these will appear as separate features. Since BERT produces vectors of length 768, this means each ``group_id`` will have ``768 * [number of message aggregations]`` features. Each dimension of the aggregated BERT embedding vector then serves as a distinct feature in the predictive model.
+
+
+Sentence Transformers
+-------------
+
+DLATK also allows for the user of Sentence Transformers. Sentence Transformers embed language at a sentence level and (when using the last layer) have been fine tuned to preserve cosine similarity. This means that the embeddings for similar sentences are projected closer to one another in the embedding space than sentences that are less related.
+
+Note: Sentence Transformers requires Python 3.9
+
+In DLATK, Sentence Transformers function the same way as regular transformers, with a few notable differences.
+First, use the ``--add_sent_emb_feat`` instead of the ``--add_emb_feat`` flag as in the sample command below. All other arguments/flags should function the same as regular Transformers. 
+
+.. code-block:: bash
+
+	dlatkInterface.py -d dla_tutorial -t msgs_xxx -c user_id --add_sent_emb_feat --emb_model sentence-transformers/all-MiniLM-L6-v2
+
+#. Sentence transformers only have message and user level aggregation
+#. The default layer for sentence transformers is the last layer (as this layer possesses the cosine similarity property), as opposed to the second to last layer (It is unknown how much the cosine similarity is preserved when layer aggregation is used)
+#. You can find a list of sentence transformer models `here <https://huggingface.co/sentence-transformers#:~:text=for%20semantic%20search-,Models,126,-Sort%3A%C2%A0%20Recently/>`_

--- a/tests/sentence_transformer.sh
+++ b/tests/sentence_transformer.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# DLATK Sentence-Transformers integration smoke test (uses existing DB: dla_tutorial)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DLATK="${ROOT}/dlatkInterface.py"
+
+# Use your conda env's python if provided; otherwise fall back to python3
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "SKIP: python not found at PYTHON_BIN=$PYTHON_BIN"
+  exit 0
+fi
+
+echo "[dlatk-sent-emb] starting (DB=dla_tutorial)"
+
+# --- Preflight ---
+if ! command -v mysql >/dev/null 2>&1; then
+  echo "SKIP: mysql client not found"
+  exit 0
+fi
+
+# Require Python >= 3.9 (avoid tokenizer overflow issues)
+"$PYTHON_BIN" - <<'PY' || { echo "SKIP: Python < 3.9 (DLATK ST requires 3.9)"; exit 0; }
+import sys; sys.exit(0 if sys.version_info >= (3,9) else 1)
+PY
+
+if [[ ! -f "$DLATK" ]] && ! command -v dlatkInterface.py >/dev/null 2>&1; then
+  echo "SKIP: dlatkInterface.py not found (run from repo root or install DLATK)"
+  exit 0
+fi
+
+# MySQL connection (defaults to ~/.my.cnf if present)
+MYSQL_HOST="${MYSQL_HOST:-localhost}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+MYSQL_USER="${MYSQL_USER:-}"
+MYSQL_PWD="${MYSQL_PWD:-}"  
+
+DB="dla_tutorial"
+TABLE="msgs_sts$RANDOM"
+
+mysql_exec() {
+  local SQL="$1"
+  if [[ -n "$MYSQL_PWD" ]]; then
+    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PWD" -N -e "$SQL"
+  else
+    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -N -e "$SQL"
+  fi
+}
+
+# Ensure we can USE dla_tutorial
+mysql_exec "USE \`$DB\`; SELECT 1;" >/dev/null 2>&1 || {
+  echo "FAIL: Cannot USE database $DB with user $MYSQL_USER"
+  exit 1
+}
+
+# Clean up handler: drop our msgs table and any feat tables we created
+cleanup() {
+  mysql_exec "USE \`$DB\`; DROP TABLE IF EXISTS \`$TABLE\`, \`$TABLE\`_bert_trunc;" >/dev/null 2>&1 || true
+  drop_feats_for() {
+    local SRC="$1"
+    while read -r FT; do
+      [[ -z "${FT:-}" ]] && continue
+      mysql_exec "USE \`$DB\`; DROP TABLE IF EXISTS \`$FT\`;" >/dev/null 2>&1 || true
+    done < <(mysql_exec "SELECT table_name FROM information_schema.tables
+                        WHERE table_schema='${DB}'
+                          AND table_name LIKE CONCAT('feat\$','%','\$','${SRC}','\$','user_id','%');")
+  }
+  drop_feats_for "$TABLE"
+  drop_feats_for "${TABLE}_bert_trunc"
+}
+
+
+trap cleanup EXIT
+
+# Create tiny msgs table and insert pairs
+mysql_exec "USE \`$DB\`;
+  CREATE TABLE \`$TABLE\` (
+    message_id BIGINT PRIMARY KEY,
+    user_id VARCHAR(64),
+    message TEXT
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"
+
+# Add index on user_id (speeds up DLATK read & silences warning)
+mysql_exec "USE \`$DB\`; ALTER TABLE \`$TABLE\` ADD INDEX (\`user_id\`);"
+
+mysql_exec "USE \`$DB\`;
+  INSERT INTO \`$TABLE\` (message_id,user_id,message) VALUES
+   (1,'u1','A man is playing a guitar.'),
+   (2,'u2','A person is playing a guitar.'),
+   (3,'u3','A child is running through a field of grass.'),
+   (4,'u4','A kid runs through the grass.'),
+   (5,'u5','An airplane is flying in the sky.'),
+   (6,'u6','A jet aircraft is soaring in the air.'),
+   (7,'u7','A man is playing a guitar.'),
+   (8,'u8','A woman is making a sandwich.'),
+   (9,'u9','Two dogs are running through a field.'),
+   (10,'u10','There are no animals outside.');"
+
+# Models to test (BERT optional if tokenizer overflow persists)
+MODELS=("sentence-transformers/stsb-distilroberta-base-v2")
+MODELS+=("sentence-transformers/bert-base-nli-mean-tokens")
+if [[ "${INCLUDE_MXBAI:-0}" == "1" ]]; then
+  MODELS+=("mixedbread-ai/mxbai-embed-xsmall-v1")
+fi
+
+run_dlatk() {
+  if [[ -f "$DLATK" ]]; then
+    "$PYTHON_BIN" "$DLATK" "$@"
+  else
+    dlatkInterface.py "$@"
+  fi
+}
+
+find_feat_table() {
+  local logfile="$1"
+  local src_table="$2"
+
+  # Parse DLATK's line first
+  local ft
+  ft="$(awk -F' - ' '/^Feature table(s) - /{print $2}' "$logfile" | tail -n1)"
+  if [[ -n "$ft" ]]; then
+    echo "$ft"
+    return
+  fi
+
+  # Fallback to information_schema
+  mysql_exec "SELECT table_name
+              FROM information_schema.tables
+              WHERE table_schema='${DB}'
+                AND table_name LIKE CONCAT('feat\$','%','\$','${src_table}','\$','user_id','%')
+              ORDER BY create_time DESC
+              LIMIT 1;"
+}
+
+check_model() {
+  local MODEL="$1"
+  echo "[run] $MODEL"
+
+  # Choose which table to run on
+  local RUN_TABLE="$TABLE"
+
+  # Truncate messages to avoid tokenizer overflow (BERT only)
+  if [[ "$MODEL" == "sentence-transformers/bert-base-nli-mean-tokens" ]]; then
+    RUN_TABLE="${TABLE}_bert_trunc"
+    local MAX_CHARS="${MAX_CHARS:-2000}"
+    mysql_exec "USE \`$DB\`;
+      DROP TABLE IF EXISTS \`${RUN_TABLE}\`;
+      CREATE TABLE \`${RUN_TABLE}\` LIKE \`${TABLE}\`;
+      INSERT INTO \`${RUN_TABLE}\` (message_id, user_id, message)
+      SELECT message_id, user_id, LEFT(message, ${MAX_CHARS})
+      FROM \`${TABLE}\`;
+      ALTER TABLE \`${RUN_TABLE}\` ADD INDEX (\`user_id\`);"
+  fi
+
+  # capture DLATK stdout/stderr
+  local LOG
+  LOG="$(mktemp -t dlatk_log.XXXXXX)" || { echo "mktemp failed"; return 1; }
+
+  if ! run_dlatk -d "$DB" -t "$RUN_TABLE" -c "user_id" \
+        --messageid_field "message_id" --message_field "message" \
+        --add_sent_emb_feat --emb_model "$MODEL" | tee "$LOG"
+  then
+    echo "FAIL: DLATK run failed for $MODEL"
+    rm -f "$LOG"
+    return 1
+  fi
+
+  local FEAT_TABLE=""
+  FEAT_TABLE="$(find_feat_table "$LOG" "$RUN_TABLE" | tail -n1 || true)"
+  rm -f "$LOG"
+
+  if [[ -z "$FEAT_TABLE" ]]; then
+    echo "FAIL: could not find feature table for $MODEL"
+    return 1
+  fi
+
+  # pull vectors and score cosine similarities
+  local TMP_TSV
+  TMP_TSV="$(mktemp -t dlatk_vecs.XXXXXX)" || { echo "mktemp failed"; return 1; }
+
+  mysql_exec "USE \`$DB\`; SELECT group_id, feat, value
+              FROM \`$FEAT_TABLE\`
+              WHERE group_id IN ('u1','u2','u3','u4','u5','u6','u7','u8','u9','u10');" > "$TMP_TSV"
+
+  if ! grep -q . "$TMP_TSV"; then
+    echo "FAIL: no feature rows returned from $FEAT_TABLE (check group_id filter vs -c user_id/message_id)"
+    rm -f "$TMP_TSV"
+    return 1
+  fi
+
+  "$PYTHON_BIN" - "$MODEL" "$TMP_TSV" <<'PY'
+import sys, json, math
+from collections import defaultdict
+model, path = sys.argv[1], sys.argv[2]
+vecs = defaultdict(dict)
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        gid, feat, val = line.rstrip("\n").split("\t")
+        vecs[gid][feat] = float(val)
+def dot(a,b): return sum(a[k]*b[k] for k in (a.keys() & b.keys()))
+def norm(a):  return math.sqrt(sum(v*v for v in a.values())) or 1.0
+def cos(a,b): return dot(a,b) / (norm(a)*norm(b))
+high_pairs = [("u1","u2"), ("u3","u4"), ("u5","u6")]
+low_pairs  = [("u7","u8"), ("u9","u10")]
+high = [cos(vecs[i], vecs[j]) for (i,j) in high_pairs]
+low  = [cos(vecs[i], vecs[j]) for (i,j) in low_pairs]
+mh, ml = sum(high)/len(high), sum(low)/len(low)
+sep = mh - ml
+ok = (mh > 0.60) and (ml < 0.40) and (sep >= 0.25)
+print(json.dumps({"model": model, "mean_high": mh, "mean_low": ml, "sep": sep, "ok": ok}))
+sys.exit(0 if ok else 1)
+PY
+  local rc=$?
+  rm -f "$TMP_TSV"
+
+  if [[ $rc -eq 0 ]]; then
+    echo "PASS: $MODEL"
+  else
+    echo "FAIL: $MODEL"
+  fi
+  return $rc
+}
+
+fail=0
+for m in "${MODELS[@]}"; do
+  check_model "$m" || fail=1
+done
+
+if [[ $fail -eq 0 ]]; then
+  echo "[dlatk-sent-emb] done"
+else
+  echo "[dlatk-sent-emb] failed"
+  exit 1
+fi
+


### PR DESCRIPTION
Unit test location: `dlatk/tests$ ./sentence_transformer.sh`
env directory: `dlatk_py39`

Unit test outputs:
```bash
/cronus_data/lbui/dlatk/tests$ ./sentence_transformer.sh
[dlatk-sent-emb] starting (DB=dla_tutorial)
[run] sentence-transformers/stsb-distilroberta-base-v2

-----
DLATK Interface Initiated: 2025-08-26 16:24:11
-----
WARNING: run --add_sent_tokenized on the message table to avoid tokenizing it every time you generate embeddings
/cronus_data/lbui/envs/dlatk_py39/lib/python3.9/site-packages/transformers/utils/hub.py:128: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Done.
SQL QUERY: DROP TABLE IF EXISTS feat$stsb_di_ba_v2_meL6con$msgs_sts29717$user_id
SQL QUERY: CREATE TABLE feat$stsb_di_ba_v2_meL6con$msgs_sts29717$user_id ( id BIGINT(16) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, group_id varchar(64), feat VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, value DOUBLE, group_norm DOUBLE, KEY `correl_field` (`group_id`), KEY `feature` (`feat`)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin ENGINE=MYISAM
finding messages for 10 'user_id's
SQL QUERY: ALTER TABLE feat$stsb_di_ba_v2_meL6con$msgs_sts29717$user_id DISABLE KEYS
/chronos_data/lbui/dlatk/dlatk/featureExtractor.py:1776: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  input_sents.append(torch.tensor(tokens['input_ids'], dtype=torch.long).squeeze(0))
Done Reading / Inserting.
Adding Keys (if goes to keycache, then decrease MAX_TO_DISABLE_KEYS or run myisamchk -n).
SQL QUERY: ALTER TABLE feat$stsb_di_ba_v2_meL6con$msgs_sts29717$user_id ENABLE KEYS
Done

-------
Settings:

Database - dla_tutorial
Corpus - msgs_sts29717
Group ID - user_id
Feature table(s) - feat$stsb_di_ba_v2_meL6con$msgs_sts29717$user_id
-------
Interface Runtime: 11.57 seconds
DLATK exits with success! A good day indeed  ¯\_(ツ)_/¯.


query: SELECT column_type FROM information_schema.columns WHERE table_schema='dla_tutorial' AND table_name='msgs_sts29717' AND column_name='user_id'
{"model": "sentence-transformers/stsb-distilroberta-base-v2", "mean_high": 0.8373890037876537, "mean_low": 0.18489623130927868, "sep": 0.652492772478375, "ok": true}
PASS: sentence-transformers/stsb-distilroberta-base-v2
[run] sentence-transformers/bert-base-nli-mean-tokens

-----
DLATK Interface Initiated: 2025-08-26 16:24:27
-----
WARNING: run --add_sent_tokenized on the message table to avoid tokenizing it every time you generate embeddings
/cronus_data/lbui/envs/dlatk_py39/lib/python3.9/site-packages/transformers/utils/hub.py:128: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Done.
SQL QUERY: DROP TABLE IF EXISTS feat$bert_ba_nl_me_to_meL12con$msgs_sts29717_bert_trunc$user_id
SQL QUERY: CREATE TABLE feat$bert_ba_nl_me_to_meL12con$msgs_sts29717_bert_trunc$user_id ( id BIGINT(16) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, group_id varchar(64), feat VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, value DOUBLE, group_norm DOUBLE, KEY `correl_field` (`group_id`), KEY `feature` (`feat`)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin ENGINE=MYISAM
finding messages for 10 'user_id's
SQL QUERY: ALTER TABLE feat$bert_ba_nl_me_to_meL12con$msgs_sts29717_bert_trunc$user_id DISABLE KEYS
/chronos_data/lbui/dlatk/dlatk/featureExtractor.py:1776: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  input_sents.append(torch.tensor(tokens['input_ids'], dtype=torch.long).squeeze(0))
Done Reading / Inserting.
Adding Keys (if goes to keycache, then decrease MAX_TO_DISABLE_KEYS or run myisamchk -n).
SQL QUERY: ALTER TABLE feat$bert_ba_nl_me_to_meL12con$msgs_sts29717_bert_trunc$user_id ENABLE KEYS
Done

-------
Settings:

Database - dla_tutorial
Corpus - msgs_sts29717_bert_trunc
Group ID - user_id
Feature table(s) - feat$bert_ba_nl_me_to_meL12con$msgs_sts29717_bert_trunc$user_id
-------
Interface Runtime: 10.61 seconds
DLATK exits with success! A good day indeed  ¯\_(ツ)_/¯.


query: SELECT column_type FROM information_schema.columns WHERE table_schema='dla_tutorial' AND table_name='msgs_sts29717_bert_trunc' AND column_name='user_id'
{"model": "sentence-transformers/bert-base-nli-mean-tokens", "mean_high": 0.9447077742326028, "mean_low": 0.0943410889517336, "sep": 0.8503666852808691, "ok": true}
PASS: sentence-transformers/bert-base-nli-mean-tokens
[dlatk-sent-emb] done
```